### PR TITLE
Update NewCityhallVR.md「新市庁舎VR体験会の様子」

### DIFF
--- a/_projects/NewCityhallVR.md
+++ b/_projects/NewCityhallVR.md
@@ -35,11 +35,13 @@ author_staff_member:
 
 ## 新市庁舎VR体験会の様子
 
-- ナレジックス株式会社における体験会
+- 仮設北仲ブリックにおける体験会
 ![](/images/projects/chvr_event_1.jpg)
 
+- YAMAGATA株式会社における体験会
 ![](/images/projects/chvr_event_2.jpg)
 
+- 泰生ポーチにおける体験会
 ![](/images/projects/chvr_event_3.jpg)
 
 - 情報科学専門学校における体験会（2017-08-31）


### PR DESCRIPTION
issue「横浜市庁舎VR」より修正
・「新市庁舎VR体験会の様子」の3枚の写真のキャプションを修正